### PR TITLE
fix: Ensure strict schema definitions

### DIFF
--- a/src/apiGatewayThrottlingPlugin.js
+++ b/src/apiGatewayThrottlingPlugin.js
@@ -80,6 +80,7 @@ class ApiGatewayThrottlingPlugin {
       type: 'object',
       properties: {
         apiGatewayThrottling: {
+          type: 'object',
           properties: {
             maxRequestsPerSecond: { type: 'number' },
             maxConcurrentRequests: { type: 'number' }
@@ -93,6 +94,7 @@ class ApiGatewayThrottlingPlugin {
       type: 'object',
       properties: {
         throttling: {
+          type: 'object',
           properties: {
             maxRequestsPerSecond: { type: 'number' },
             maxConcurrentRequests: { type: 'number' }


### PR DESCRIPTION
Closes: https://github.com/DianaIonita/serverless-api-gateway-throttling/issues/19