### PR TITLE
Fixed Error: "Unable to find Route by key within route settings" for ApiGatewayV2(HTTP) throttling

### DIFF
--- a/src/updateHttpApiStageThrottling.js
+++ b/src/updateHttpApiStageThrottling.js
@@ -48,10 +48,7 @@ const createRouteSettingsForHttpApiEndpoint = (endpointSettings, serverless) => 
 
     let { path, method } = httpApiEvent;
     //Throttling route setting should be created with the same method type as defined in the httpApi.
-    const routeSettings = {
-        ...routeSettingsForMethod(path, method.toUpperCase(), endpointSettings)
-    };
-    return routeSettings;
+    return routeSettingsForMethod(path, method.toUpperCase(), endpointSettings);
 }
 
 const routeSettingsForMethod = (path, method, endpointSettings) => {

--- a/src/updateHttpApiStageThrottling.js
+++ b/src/updateHttpApiStageThrottling.js
@@ -50,7 +50,7 @@ const createRouteSettingsForHttpApiEndpoint = (endpointSettings, serverless) => 
 
     let routeSettings = {};
     if (method.toUpperCase() == 'ANY') {
-        let httpMethodsToConfigureThrottlingFor = ['GET', 'DELETE', 'HEAD', 'OPTIONS', 'PATCH', 'POST', 'PUT'];
+        let httpMethodsToConfigureThrottlingFor = ['ANY'];
         for (let methodWithThrottlingSettings of httpMethodsToConfigureThrottlingFor) {
             routeSettings = {
                 ...routeSettings,

--- a/src/updateHttpApiStageThrottling.js
+++ b/src/updateHttpApiStageThrottling.js
@@ -47,23 +47,10 @@ const createRouteSettingsForHttpApiEndpoint = (endpointSettings, serverless) => 
     }
 
     let { path, method } = httpApiEvent;
-
-    let routeSettings = {};
-    if (method.toUpperCase() == 'ANY') {
-        let httpMethodsToConfigureThrottlingFor = ['ANY']; //In ApiGatewaV2(HTTP), For Method type ANY, the Throttling route should also have ANY method.
-        for (let methodWithThrottlingSettings of httpMethodsToConfigureThrottlingFor) {
-            routeSettings = {
-                ...routeSettings,
-                ...routeSettingsForMethod(path, methodWithThrottlingSettings, endpointSettings)
-            }
-        };
-    }
-    else {
-        routeSettings = {
-            ...routeSettings,
-            ...routeSettingsForMethod(path, method, endpointSettings),
-        }
-    }
+    //Throttling route shoul be created with same method type as te httpApi
+    const routeSettings = {
+        ...routeSettingsForMethod(path, method.toUpperCase(), endpointSettings)
+    };
     return routeSettings;
 }
 

--- a/src/updateHttpApiStageThrottling.js
+++ b/src/updateHttpApiStageThrottling.js
@@ -47,7 +47,7 @@ const createRouteSettingsForHttpApiEndpoint = (endpointSettings, serverless) => 
     }
 
     let { path, method } = httpApiEvent;
-    //Throttling route shoul be created with same method type as te httpApi
+    //Throttling route setting should be created with the same method type as defined in the httpApi.
     const routeSettings = {
         ...routeSettingsForMethod(path, method.toUpperCase(), endpointSettings)
     };

--- a/src/updateHttpApiStageThrottling.js
+++ b/src/updateHttpApiStageThrottling.js
@@ -50,7 +50,7 @@ const createRouteSettingsForHttpApiEndpoint = (endpointSettings, serverless) => 
 
     let routeSettings = {};
     if (method.toUpperCase() == 'ANY') {
-        let httpMethodsToConfigureThrottlingFor = ['ANY'];
+        let httpMethodsToConfigureThrottlingFor = ['ANY']; //In ApiGatewaV2(HTTP), For Method type ANY, the Throttling route should also have ANY method.
         for (let methodWithThrottlingSettings of httpMethodsToConfigureThrottlingFor) {
             routeSettings = {
                 ...routeSettings,


### PR DESCRIPTION
Hello Diana,

I was using your module to create throttling for my HTTP request with "ANY" method on ApiGatewayV2.
I was getting following error: 
`Unable to find Route by key DELETE /{proxy+} within the provided RouteSettings`
I found that for methods with "ANY" type in HTTP gateway, they should have route setting with same method(i.e ANY). So no need to create for all method types since it fails with above error.
I have tested these changes in my live environment as well, and they work fine.

Thanks,
Varad
